### PR TITLE
Fix CircleCI build failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ jobs:
             curl -O https://dl.google.com/go/$GOLANG_INSTALLER_NAME
             tar -xzf $GOLANG_INSTALLER_NAME
             export PATH="$PROJECT_ROOT/go/bin:$PATH"
-            git submodule update --init --remote --recursive
-            xcodebuild clean build -scheme FirefoxPrivateNetworkVPN -destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' -derivedDataPath "$PROJECT_ROOT/$DERIVED_DATA"
+            git submodule update --init --recursive
+            xcodebuild clean build -scheme FirefoxPrivateNetworkVPN -destination 'generic/platform=iOS Simulator' -sdk iphonesimulator13.1 -derivedDataPath "$PROJECT_ROOT/$DERIVED_DATA"
       - run:
           name: Compress .app file for artifact storage
           command: |


### PR DESCRIPTION
## SUMMARY
This PR fixes the recent build failures in CircleCI, and also now creates a simulator-agnostic `.app` file using the iOS 13.1 SDK, instead of a build tied to the iPhone 8 simulator.

For more context on the build failures, the root cause was the `--remote` flag in the `git submodule` command, which pulls in the latest commits for the submodule, instead of leaving it at the commit specified in the base project. Thus, removing this flag fixed the issue 👍 