### PR TITLE
Print Carthage's exit code to the console

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - carthage-cache-v3-{{ .Branch }}-{{ checksum "Cartfile.resolved" }}
+            - carthage-cache-v4-{{ .Branch }}-{{ checksum "Cartfile.resolved" }}
       - run: 
           name: Install SwiftLint
           command: |

--- a/bootstrap
+++ b/bootstrap
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 carthage bootstrap --platform ios --no-use-binaries
+echo $?
 
 if [ $? -eq 0 ]; then
 	cp Cartfile.resolved Carthage


### PR DESCRIPTION
## SUMMARY
This PR adds a slight change to print Carthage's exit code to the console after the command finishes executing. After merging my PR yesterday I noticed that the subsequent `develop` build (https://circleci.com/gh/mozilla-mobile/guardian-vpn-ios/156) failed to install its Carthage dependencies, yet still continued executing subsequent steps. As such, I want to see exactly what Carthage's exit code is in this scenario.

I've also incremented the Carthage cache key, so the next `develop` build will rebuild the dependencies.