### PR TITLE
Fix key that the cache was being saved under

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Build Carthage dependencies
           command: ./bootstrap-if-needed
       - save_cache:
-          key: carthage-cache-v1-{{ .Branch }}-{{ checksum "Cartfile.resolved" }}
+          key: carthage-cache-v4-{{ .Branch }}-{{ checksum "Cartfile.resolved" }}
           paths:
             - Carthage/
       - run: 


### PR DESCRIPTION
## SUMMARY
Turns out each build was saving the cache with an outdated key, so newer builds would never have a cache hit :( This PR fixes that!