### PR TITLE
Store Carthage exit code in a local variable

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 carthage bootstrap --platform ios --no-use-binaries
-echo $?
+EXIT_CODE="$?"
 
-if [ $? -eq 0 ]; then
+if [ $EXIT_CODE -eq 0 ]; then
 	cp Cartfile.resolved Carthage
 fi
-exit $?
+exit $EXIT_CODE


### PR DESCRIPTION
## SUMMARY
This PR *finally* properly handles the scenario where Carthage fails to install all of its dependencies. In this situation the exit code is now properly propagated to the topmost script, which will then cause CircleCI to fail the build and not execute any subsequent `run:` steps.