### PR TITLE
PGIOS-78 Terminating, then relaunching app after connecting to a server results in the disconnected state

### DIFF
--- a/FirefoxPrivateNetworkVPN/Networking/NetworkingEnums.swift
+++ b/FirefoxPrivateNetworkVPN/Networking/NetworkingEnums.swift
@@ -42,6 +42,7 @@ enum GuardianRelativeRequest {
         }
     }
 }
+
 enum GuardianError: Error {
     case couldNotDecodeFromJson
     case couldNotCreateBody

--- a/FirefoxPrivateNetworkVPN/ViewControllers/HomeViewController.swift
+++ b/FirefoxPrivateNetworkVPN/ViewControllers/HomeViewController.swift
@@ -57,7 +57,7 @@ class HomeViewController: UIViewController, Navigating {
     }
 
     private func subscribeToToggle() {
-        vpnToggleView.vpnSwitchEvent?.subscribe { isOnEvent in
+        vpnToggleView.vpnSwitchEvent?.skip(1).subscribe { isOnEvent in
             guard let isOn = isOnEvent.element else { return }
             if isOn {
                 DependencyFactory.sharedFactory.tunnelManager

--- a/FirefoxPrivateNetworkVPN/Views/VPNToggleView.swift
+++ b/FirefoxPrivateNetworkVPN/Views/VPNToggleView.swift
@@ -36,11 +36,14 @@ class VPNToggleView: UIView {
         Bundle.main.loadNibNamed(String(describing: VPNToggleView.self), owner: self, options: nil)
         view.frame = bounds
         addSubview(view)
+
+        let vpnStateEvent = tunnelManager.stateEvent
+            .observeOn(MainScheduler.instance)
+            .skip(1)
+
         Observable
-            .zip(tunnelManager.stateEvent, updateUIEvent.startWith(())) { [weak self] state, _ in
-                DispatchQueue.main.async {
-                    self?.update(with: state)
-                }
+            .zip(vpnStateEvent, updateUIEvent.startWith(())) { [weak self] state, _ in
+                self?.update(with: state)
 
                 DispatchQueue.main.asyncAfter(deadline: .now() + (state.delay ?? 0)) {
                     self?.updateUIEvent.onNext(())


### PR DESCRIPTION
Add skip(1) RxSwift operator to both the stateEvent and vpnSwitchEvent so it doesn't react to the first event which is hardcoded to .off and turning the toggle off in the case that it should be on