### PR TITLE
Update to RxSwift version that removes UIWebView references

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "Quick/Quick"
 github "Quick/Nimble"
-github "ReactiveX/RxSwift" "529681e180f79559af81aa296dcc17111eeb8a8a"
+github "ReactiveX/RxSwift" "9b31a15520306b073cb9d46456f64826c1d6dcab"
 github "airbnb/lottie-ios" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "v8.0.4"
 github "Quick/Quick" "v2.2.0"
-github "ReactiveX/RxSwift" "529681e180f79559af81aa296dcc17111eeb8a8a"
+github "ReactiveX/RxSwift" "9b31a15520306b073cb9d46456f64826c1d6dcab"
 github "airbnb/lottie-ios" "477959517babbeb46e69a6e94ae1c666af559e96"


### PR DESCRIPTION
1. Change cartfile to checkout commit "529681e180f79559af81aa296dcc17111eeb8a8a" which is the commit that removes all usage of UIWebView
2. Run `carthage update` to update the resolve file