### PR TITLE
Handles max device error on login modal dismissing

### DIFF
--- a/FirefoxPrivateNetworkVPN/Singletons/NavigationCoordinator.swift
+++ b/FirefoxPrivateNetworkVPN/Singletons/NavigationCoordinator.swift
@@ -62,12 +62,12 @@ class NavigationCoordinator: NavigationCoordinating {
                 self.appDelegate?.window?.rootViewController = landingViewController
                 self.currentViewController = landingViewController
 
+            case (.login, .landing):
+                self.currentViewController?.dismiss(animated: true, completion: nil)
+
                 if context == .maxDevicesError {
                     self.navigate(from: .landing, to: .home, context: context)
                 }
-
-            case (.login, .landing):
-                self.currentViewController?.dismiss(animated: true, completion: nil)
 
             // To Home
             case (.loading, .home), (.landing, .home), (.login, .home):


### PR DESCRIPTION
This is to address the regression caused by https://github.com/mozilla-mobile/guardian-vpn-ios/commit/2c8ad37de35cc07c23a4c36f314ddd9aa87b94d9 when handling max device error.