### PR TITLE
Replace BehaviorRelay with PublishSubject to avoid maintain unused internal state

### DIFF
--- a/FirefoxPrivateNetworkVPN/Protocols/ReleaseMonitoring.swift
+++ b/FirefoxPrivateNetworkVPN/Protocols/ReleaseMonitoring.swift
@@ -13,7 +13,7 @@ import RxSwift
 import RxCocoa
 
 protocol ReleaseMonitoring {
-    var updateStatus: Observable<UpdateStatus?> { get }
+    var updateStatus: Observable<UpdateStatus> { get }
 
     func start()
     func stop()

--- a/FirefoxPrivateNetworkVPN/Singletons/ReleaseMonitor.swift
+++ b/FirefoxPrivateNetworkVPN/Singletons/ReleaseMonitor.swift
@@ -18,11 +18,14 @@ class ReleaseMonitor: ReleaseMonitoring {
 
     private static let timeInterval: TimeInterval = 21600
     private var timer: DispatchSourceTimer?
+    private var _updateStatus = PublishSubject<UpdateStatus>()
 
-    private var _updateStatus = BehaviorRelay<UpdateStatus?>(value: ReleaseInfo.fetchFromUserDefaults()?.getUpdateStatus())
+    var updateStatus: Observable<UpdateStatus> {
+        guard let updateStatus = ReleaseInfo.fetchFromUserDefaults()?.getUpdateStatus() else {
+            return _updateStatus.asObservable()
+        }
 
-    var updateStatus: Observable<UpdateStatus?> {
-        return _updateStatus.asObservable()
+        return _updateStatus.startWith(updateStatus).asObservable()
     }
 
     private var pollingDelay: DispatchTime {
@@ -52,7 +55,7 @@ class ReleaseMonitor: ReleaseMonitoring {
             let releaseInfo = ReleaseInfo(with: release)
             releaseInfo.saveToUserDefaults()
 
-            self?._updateStatus.accept(releaseInfo.getUpdateStatus())
+            self?._updateStatus.onNext(releaseInfo.getUpdateStatus())
         }
     }
 }


### PR DESCRIPTION
Also we wouldn't have to emit invalid events (aka the `nil` event) that subscribers should filter out