### PR TITLE
Fix call to /versions endpoint

### DIFF
--- a/FirefoxPrivateNetworkVPN/Networking/NetworkingEnums.swift
+++ b/FirefoxPrivateNetworkVPN/Networking/NetworkingEnums.swift
@@ -42,7 +42,7 @@ enum GuardianRelativeRequest {
         case .removeDevice(let deviceKey):
             return prefix + "device/" + deviceKey
         case .versions:
-            return prefix + "versions/"
+            return prefix + "versions"
         }
     }
 }


### PR DESCRIPTION
## SUMMARY
It turns out FxA's `/versions` endpoint doesn't like it if you add a trailing forward-slash. This PR fixes that!