### PR TITLE
Fix Tests

### DIFF
--- a/FirefoxPrivateNetworkVPNTests/Mocks/MockGuardianAPI.swift
+++ b/FirefoxPrivateNetworkVPNTests/Mocks/MockGuardianAPI.swift
@@ -14,9 +14,10 @@ import RxSwift
 @testable import Firefox_Private_Network_VPN
 
 class MockGuardianAPI: NetworkRequesting {
-    static var apiCallObservable = PublishSubject<Void>()
 
-    static func initiateUserLogin(completion: @escaping (Result<LoginCheckpointModel, Error>) -> Void) {
+    var apiCallObservable = PublishSubject<Void>()
+
+    func initiateUserLogin(completion: @escaping (Result<LoginCheckpointModel, Error>) -> Void) {
         apiCallObservable.onNext(())
         guard let jsonUserURL = Bundle.main.url(forResource: "loginCheckpointModel", withExtension: "json"),
             let loginCheckpointModel = try? JSONDecoder().decode(LoginCheckpointModel.self, from: Data(contentsOf: jsonUserURL))
@@ -24,7 +25,7 @@ class MockGuardianAPI: NetworkRequesting {
         completion(Result.success(loginCheckpointModel))
     }
 
-    static func accountInfo(token: String, completion: @escaping (Result<User, Error>) -> Void) {
+    func accountInfo(token: String, completion: @escaping (Result<User, Error>) -> Void) {
         apiCallObservable.onNext(())
         guard let jsonUserURL = Bundle.main.url(forResource: "user", withExtension: "json"),
             let user = try? JSONDecoder().decode(User.self, from: Data(contentsOf: jsonUserURL))
@@ -32,7 +33,7 @@ class MockGuardianAPI: NetworkRequesting {
         completion(Result.success(user))
     }
 
-    static func verify(urlString: String, completion: @escaping (Result<VerifyResponse, Error>) -> Void) {
+    func verify(urlString: String, completion: @escaping (Result<VerifyResponse, Error>) -> Void) {
         apiCallObservable.onNext(())
         guard let jsonUserURL = Bundle.main.url(forResource: "verifyResponse", withExtension: "json"),
             let verifyResponse = try? JSONDecoder().decode(VerifyResponse.self, from: Data(contentsOf: jsonUserURL))
@@ -40,7 +41,7 @@ class MockGuardianAPI: NetworkRequesting {
         completion(Result.success(verifyResponse))
     }
 
-    static func availableServers(with token: String, completion: @escaping (Result<[VPNCountry], Error>) -> Void) {
+    func availableServers(with token: String, completion: @escaping (Result<[VPNCountry], Error>) -> Void) {
         apiCallObservable.onNext(())
         guard let jsonUserURL = Bundle.main.url(forResource: "vpnCountry", withExtension: "json"),
             let vpnCountries = try? JSONDecoder().decode([VPNCountry].self, from: Data(contentsOf: jsonUserURL))
@@ -48,7 +49,7 @@ class MockGuardianAPI: NetworkRequesting {
         completion(Result.success(vpnCountries))
     }
 
-    static func addDevice(with token: String, body: [String: Any], completion: @escaping (Result<Device, Error>) -> Void) {
+    func addDevice(with token: String, body: [String: Any], completion: @escaping (Result<Device, Error>) -> Void) {
         apiCallObservable.onNext(())
         guard let jsonUserURL = Bundle.main.url(forResource: "device", withExtension: "json"),
             let device = try? JSONDecoder().decode(Device.self, from: Data(contentsOf: jsonUserURL))
@@ -56,7 +57,7 @@ class MockGuardianAPI: NetworkRequesting {
         completion(Result.success(device))
     }
 
-    static func removeDevice(with token: String, deviceKey: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func removeDevice(with token: String, deviceKey: String, completion: @escaping (Result<Void, Error>) -> Void) {
         apiCallObservable.onNext(())
         completion(Result.success(()))
     }


### PR DESCRIPTION
Update MockGuardianAPI to use instance methods instead of static to conform to the refactored NetworkRequesting protocol