### PR TITLE
PGAND-230 User should be hinted once the client enter Airplane mode

### DIFF
--- a/FirefoxPrivateNetworkVPN/Managers/AccountManager.swift
+++ b/FirefoxPrivateNetworkVPN/Managers/AccountManager.swift
@@ -16,7 +16,13 @@ class AccountManager: AccountManaging, Navigating {
 
     private(set) var account: Account?
     private(set) var availableServers: [VPNCountry] = []
-    private(set) var selectedCity: VPNCity?
+    private(set) var selectedCity: VPNCity? {
+        didSet {
+            if let selectedCity = selectedCity {
+                self.accountStore.save(selectedCity: selectedCity)
+            }
+        }
+    }
     private let disposeBag = DisposeBag()
     private let guardianAPI: GuardianAPI
     private let accountStore: AccountStoring
@@ -234,7 +240,6 @@ class AccountManager: AccountManaging, Navigating {
 
     func updateSelectedCity(with newCity: VPNCity) {
         self.selectedCity = newCity
-        self.accountStore.save(selectedCity: newCity)
     }
 
     private func subscribeToExpiredSubscriptionNotification() {

--- a/FirefoxPrivateNetworkVPN/Managers/Connection Heath Monitor/ConnectionHealthMonitor.swift
+++ b/FirefoxPrivateNetworkVPN/Managers/Connection Heath Monitor/ConnectionHealthMonitor.swift
@@ -61,7 +61,7 @@ class ConnectionHealthMonitor: ConnectionHealthMonitoring {
     }
 
     private func startStateMachine() {
-        if _currentState.value == .initial {
+        if _currentState.value == .initial || _currentState.value == .stable {
             move(to: .stable)
         }
     }

--- a/FirefoxPrivateNetworkVPN/Models/VPNLocations.swift
+++ b/FirefoxPrivateNetworkVPN/Models/VPNLocations.swift
@@ -43,7 +43,7 @@ struct VPNCity: Codable {
     let servers: [VPNServer]
     let flagCode: String?
     //the higher the weight, the faster the server -> more likely the server is selected
-    var selectedServer: VPNServer?
+    private(set) var selectedServer: VPNServer?
 
     init(name: String, code: String, latitude: Float, longitude: Float, servers: [VPNServer], flagCode: String) {
         self.name = name
@@ -52,16 +52,18 @@ struct VPNCity: Codable {
         self.longitude = longitude
         self.servers = servers
         self.flagCode = flagCode
+
+        setSelectedServer()
     }
 
-    mutating func setServer() -> VPNServer? {
+    private mutating func setSelectedServer() {
         let weightSum = servers.reduce(0) {
             $0 + $1.weight
         }
 
         guard weightSum != 0 else {
             selectedServer = nil
-            return nil
+            return
         }
 
         var r = Int.random(in: 0...weightSum)
@@ -71,10 +73,9 @@ struct VPNCity: Codable {
 
             if r <= 0 {
                 selectedServer = server
-                return selectedServer
+                return
             }
         }
-        return nil
     }
 }
 

--- a/FirefoxPrivateNetworkVPN/Utilities/TunnelConfigurationBuilder.swift
+++ b/FirefoxPrivateNetworkVPN/Utilities/TunnelConfigurationBuilder.swift
@@ -27,9 +27,7 @@ struct TunnelConfigurationBuilder {
         // peers
         var peerConfigurations: [PeerConfiguration] = []
 
-        var serverCity = city
-
-        if let server = serverCity.setServer(),
+        if let server = city.selectedServer,
             let keyData = Data(base64Key: server.publicKey),
             let ipv4GatewayIP = IPv4Address(server.ipv4Gateway),
             let ipv6GatewayIP = IPv6Address(server.ipv6Gateway) {


### PR DESCRIPTION
# Story
https://jira.mozilla.com/browse/PGAND-230

# Implementation
1. Set selected server when VPNCity object is initialized to prevent setting value to the copy
2. Keep state machine working if current state is stable happening when vpn is connected and app enter foreground again
3.  save selectedCity to AccountStore everytime selectedCity is updated to prevent getting unsaved tunnel

