### PR TITLE
PGAND-267 If a user switch servers multiple times, the user could get stuck in switching state

### DIFF
--- a/FirefoxPrivateNetworkVPN/Managers/GuardianTunnelManager.swift
+++ b/FirefoxPrivateNetworkVPN/Managers/GuardianTunnelManager.swift
@@ -162,8 +162,10 @@ class GuardianTunnelManager: TunnelManaging {
             if self.internalState.value != .off {
                 let cityName = tunnel.localizedDescription ?? ""
                 let newCityName = self.accountManager.selectedCity?.name ?? ""
-                self.internalState.accept(.switching(cityName, newCityName))
-                self.isSwitchingInProgress = true
+                if cityName != newCityName {
+                    self.internalState.accept(.switching(cityName, newCityName))
+                    self.isSwitchingInProgress = true
+                }
             }
             guard let account = self.account,
                 let newCity = self.accountManager.selectedCity else {

--- a/FirefoxPrivateNetworkVPN/ViewControllers/ServersViewController.swift
+++ b/FirefoxPrivateNetworkVPN/ViewControllers/ServersViewController.swift
@@ -65,7 +65,7 @@ class ServersViewController: UIViewController, Navigating {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        super.viewWillDisappear(animated)
 
         initialVpnState = nil
 

--- a/FirefoxPrivateNetworkVPN/ViewModels/Server List/ServerListViewModel.swift
+++ b/FirefoxPrivateNetworkVPN/ViewModels/Server List/ServerListViewModel.swift
@@ -43,7 +43,9 @@ class ServerListViewModel {
 
     private var isCellSelectionDisabled: Bool {
         switch vpnStates.current {
-        case .switching, .connecting, .disconnecting:
+        case .switching:
+            return true
+        case .connecting, .disconnecting:
             return vpnStates.previous == vpnStates.current
         default:
             return false


### PR DESCRIPTION
# Bug
https://jira.mozilla.com/browse/PGAND-267

# Implementation
1. disable cell selection when vpn is switching
2. switch server only when new city is different from current one