### PR TITLE
Fix base64UrlEncode implementation to remove "="

### DIFF
--- a/FirefoxPrivateNetworkVPN/Utilities/PKCECodeGenerator.swift
+++ b/FirefoxPrivateNetworkVPN/Utilities/PKCECodeGenerator.swift
@@ -29,6 +29,7 @@ struct PKCECodeGenerator {
         return data.base64EncodedString()
                    .replacingOccurrences(of: "+", with: "-")
                    .replacingOccurrences(of: "/", with: "_")
+                   .replacingOccurrences(of: "=", with: "")
     }
 
     private static func sha256(string: String) -> Data? {


### PR DESCRIPTION
As specified in https://tools.ietf.org/html/rfc7636#appendix-A

This is untested